### PR TITLE
Escape the characters in a String using Java String rules.

### DIFF
--- a/mybuilder/repositories.bzl
+++ b/mybuilder/repositories.bzl
@@ -75,6 +75,22 @@ def rules_mybuilder_dependencies(
         server_urls = maven_servers,
     )
 
+    jvm_maven_import_external(
+        name = "mybuilder_rules_apache_commons_text",
+        artifact = "org.apache.commons:commons-text:1.8",
+        artifact_sha256 = "",
+        licenses = ["notice"],
+        server_urls = maven_servers,
+    )
+
+    jvm_maven_import_external(
+        name = "mybuilder_rules_apache_commons_lang",
+        artifact = "org.apache.commons:commons-lang3:3.10",
+        artifact_sha256 = "",
+        licenses = ["notice"],
+        server_urls = maven_servers,
+    )
+
 def rules_mybuilder_toolchains():
     # intentionally empty
     return

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <protobuf-version>3.11.4</protobuf-version>
     <junit-jupiter-version>5.6.0</junit-jupiter-version>
     <slf4j.version>1.7.25</slf4j.version>
+    <apache-text-version>1.8</apache-text-version>
+    <apache-lang-version>3.10</apache-lang-version>
   </properties>
 
   <dependencyManagement>
@@ -61,6 +63,16 @@
           <artifactId>jcl-over-slf4j</artifactId>
           <version>${slf4j.version}</version>
       </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-text</artifactId>
+          <version>${apache-text-version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>${apache-lang-version}</version>
+      </dependency>
 
       <!-- test dependencies -->
       <dependency>
@@ -88,6 +100,14 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <!-- pre-configure logging -->

--- a/src/main/java/com/salesforce/bazel/javabuilder/mybuilder/BUILD
+++ b/src/main/java/com/salesforce/bazel/javabuilder/mybuilder/BUILD
@@ -15,6 +15,8 @@ java_binary(
         "//src/main/java/com/salesforce/bazel/javabuilder/worker",
         "@mybuilder_rules_guava",
         "@mybuilder_rules_picocli",
+        "@mybuilder_rules_apache_commons_text",
+        "@mybuilder_rules_apache_commons_lang",
     ],
     runtime_deps = [
     	"@mybuilder_rules_org_slf4j_simple",

--- a/src/main/java/com/salesforce/bazel/javabuilder/mybuilder/MyBuilderCommand.java
+++ b/src/main/java/com/salesforce/bazel/javabuilder/mybuilder/MyBuilderCommand.java
@@ -19,6 +19,8 @@ import com.google.common.base.CharMatcher;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 @Command(name = "mybuilder", description = "A sample builder which generates a file")
 public class MyBuilderCommand implements Callable<Integer> {
 
@@ -64,6 +66,8 @@ public class MyBuilderCommand implements Callable<Integer> {
         if (!isDirectory(packageDirectory)) {
             createDirectories(packageDirectory);
         }
+
+        lines.replaceAll(l -> StringEscapeUtils.escapeJava(l));
 
         write(packageDirectory.resolve(format("%s.java", className)), lines);
 


### PR DESCRIPTION
# Related Issue
- (closes #5) Windows compatibility issue

# Proposed Changes
- Add dependencies: org.apache.commons.text, org.apache.commons.lang3
- Use StringEscapeUtils.escapeJava() method for escaping the characters in a String